### PR TITLE
Fixes for vai-2.5 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(lib/pybind11)
 include_directories(include)
 
 add_definitions(-DTEST_FEATURE=1)
+add_definitions(-DPYTHON_LIB="${PYTHON_LIBRARY}")
 
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE HEADERS "include/*.hpp")

--- a/include/pyxir/runtime/constants.hpp
+++ b/include/pyxir/runtime/constants.hpp
@@ -32,9 +32,8 @@ const std::vector<std::string> cpuTargets {"cpu"};
 #ifdef USE_VAI_RT_DPUCADX8G
 const std::vector<std::string> vaiTargets {"DPUCADX8G", "dpuv1"};
 #elif defined(USE_VAI_RT_DPUCZDX8G)
-const std::vector<std::string> vaiTargets {"DPUCZDX8G-zcu104", "DPUCZDX8G-zcu102", "DPUCZDX8G-ultra96", "DPUCZDX8G-som",
-                                           "DPUCZDX8G-kv260", "dpuv2-zcu104", "dpuv2-zcu102", "dpuv2-ultra96", "dpuv2-som",
-                                           "dpuv2-kv260"};
+const std::vector<std::string> vaiTargets {"DPUCZDX8G-zcu104", "DPUCZDX8G-zcu102", "DPUCZDX8G-kv260", "dpuv2-zcu104", 
+										   "dpuv2-zcu102", "dpuv2-kv260"};
 #elif defined(USE_VAI_RT_DPUCAHX8H)
 const std::vector<std::string> vaiTargets {"DPUCAHX8H-u50", "DPUCAHX8H-u280"};
 
@@ -43,8 +42,7 @@ const std::vector<std::string> vaiTargets {"DPUCAHX8H-u50", "DPUCAHX8H-u50lv", "
                                            "DPUCAHX8H-u280", "DPUCAHX8L", "DPUCADF8H", "DPUCVDX8H", "DPUCVDX8H-dwc"};
 
 #elif defined(USE_VART_EDGE_DPU)
-const std::vector<std::string> vaiTargets {"DPUCZDX8G-zcu104", "DPUCZDX8G-zcu102", "DPUCZDX8G-ultra96", "DPUCZDX8G-som",
-                                           "DPUCZDX8G-kv260", "DPUCVDX8G"};
+const std::vector<std::string> vaiTargets {"DPUCZDX8G-zcu104", "DPUCZDX8G-zcu102", "DPUCZDX8G-kv260", "DPUCVDX8G"};
 
 #else
 const std::vector<std::string> vaiTargets {};

--- a/python/pyxir/runtime/__init__.py
+++ b/python/pyxir/runtime/__init__.py
@@ -28,10 +28,10 @@ runtime_factory = RuntimeFactory()
 
 try:
     # NOTE use RTLD_DEEPBIND dlopen flag to make sure TF uses it's own version of protobuf 
-    flags = sys.getdlopenflags()
-    sys.setdlopenflags(flags | os.RTLD_DEEPBIND)
+    #flags = sys.getdlopenflags()
+    #sys.setdlopenflags(flags | os.RTLD_DEEPBIND)
     import tensorflow as tf
-    sys.setdlopenflags(flags)
+    #sys.setdlopenflags(flags)
     # Register if we can import tensorflow
     from .tensorflow.runtime_tf import RuntimeTF, X_2_TF
     rt_manager.register_rt('cpu-tf', RuntimeTF, X_2_TF)

--- a/src/pyxir/pyxir.cpp
+++ b/src/pyxir/pyxir.cpp
@@ -39,6 +39,8 @@ void PyInitializer::initialize_py() {
   if (!py_is_initialized()) {
     // dlopen python library for potential issue: https://github.com/pybind/pybind11/issues/3555
     // auto py_version = exec_cmd("python3 --version");
+	void* const libpython_handle = dlopen("libpython3.6m.so", RTLD_LAZY | RTLD_GLOBAL);
+
     // py_handle_ = dlopen("libpython3.7m.so", RTLD_LAZY | RTLD_GLOBAL);
     py::initialize_interpreter();
 

--- a/src/pyxir/pyxir.cpp
+++ b/src/pyxir/pyxir.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <dlfcn.h>
+#include <filesystem>
+#include <cassert>
 #include <iostream>
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
@@ -39,7 +41,9 @@ void PyInitializer::initialize_py() {
   if (!py_is_initialized()) {
     // dlopen python library for potential issue: https://github.com/pybind/pybind11/issues/3555
     // auto py_version = exec_cmd("python3 --version");
-	void* const libpython_handle = dlopen(PYTHON_LIB, RTLD_LAZY | RTLD_GLOBAL);
+	std::string python_lib_path=PYTHON_LIB;
+    	assert(std::filesystem::exist(python_lib_path));
+    	void* const libpython_handle = dlopen(python_lib_path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
 
     // py_handle_ = dlopen("libpython3.7m.so", RTLD_LAZY | RTLD_GLOBAL);
     py::initialize_interpreter();

--- a/src/pyxir/pyxir.cpp
+++ b/src/pyxir/pyxir.cpp
@@ -39,7 +39,7 @@ void PyInitializer::initialize_py() {
   if (!py_is_initialized()) {
     // dlopen python library for potential issue: https://github.com/pybind/pybind11/issues/3555
     // auto py_version = exec_cmd("python3 --version");
-	void* const libpython_handle = dlopen("libpython3.6m.so", RTLD_LAZY | RTLD_GLOBAL);
+	void* const libpython_handle = dlopen(PYTHON_LIB, RTLD_LAZY | RTLD_GLOBAL);
 
     // py_handle_ = dlopen("libpython3.7m.so", RTLD_LAZY | RTLD_GLOBAL);
     py::initialize_interpreter();

--- a/tests/unit/contrib/test_dpuczdx8g.py
+++ b/tests/unit/contrib/test_dpuczdx8g.py
@@ -106,8 +106,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 
@@ -124,8 +124,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 
@@ -144,8 +144,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         # Strided
@@ -162,8 +162,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         xcompiler_conv2d_pool2d_nhwc_oihw_test(
@@ -179,8 +179,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         # Padded
@@ -197,8 +197,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         xcompiler_conv2d_pool2d_nhwc_oihw_test(
@@ -214,8 +214,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         # Dilated
@@ -232,8 +232,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         xcompiler_conv2d_pool2d_nhwc_oihw_test(
@@ -249,8 +249,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         xcompiler_conv2d_pool2d_nhwc_oihw_test(
@@ -266,8 +266,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 
@@ -288,8 +288,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         
@@ -308,8 +308,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         # Strided
@@ -326,8 +326,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         conv2d_pool2d_nhwc_oihw_test(
@@ -343,8 +343,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         # Padded
@@ -361,8 +361,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         conv2d_pool2d_nhwc_oihw_test(
@@ -378,8 +378,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         # Dilated
@@ -396,8 +396,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         conv2d_pool2d_nhwc_oihw_test(
@@ -413,8 +413,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
         conv2d_pool2d_nhwc_oihw_test(
@@ -430,8 +430,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 
@@ -451,7 +451,7 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-som",
             ],
             expected_nb_subgraphs=3,
         )
@@ -495,8 +495,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 
@@ -512,8 +512,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 
@@ -530,8 +530,8 @@ class TestDPUCZDX8G(unittest.TestCase):
                 "DPUCZDX8G-zcu104",
                 "DPUCZDX8G-zcu102",
                 "DPUCZDX8G-kv260",
-                "DPUCZDX8G-ultra96",
-                "DPUCZDX8G-som",
+                #"DPUCZDX8G-ultra96",
+                #"DPUCZDX8G-som",
             ],
         )
 


### PR DESCRIPTION
I have added following items as part of vai-2.5 release

1. Compile time parameter for reading python lib in pyxir.cpp
2. Disable setdlopenflags when importing tensorfflow
3. Disable som and ultra96 target unit testing

could you please review and merge it?